### PR TITLE
Various fixes for the MultiTracker, particularly the MCF test case

### DIFF
--- a/Apps/MultiTrackerSim/MeshIO.cpp
+++ b/Apps/MultiTrackerSim/MeshIO.cpp
@@ -13,11 +13,10 @@ bool MeshIO::save(LosTopos::SurfTrack & st, const std::string & filename, bool b
     if (binary)
     {
         std::ofstream os(filename.c_str(), std::ios::binary);
-        size_t n;
         
-        n = st.m_mesh.nv();
-        os.write((char *)&n, sizeof (size_t));
-        for (size_t i = 0; i < n; i++)
+        const size_t nv = st.m_mesh.nv();
+        os.write((char *)&nv, sizeof (size_t));
+        for (size_t i = 0; i < nv; i++)
         {
             LosTopos::Vec3d x = st.get_position(i);
             os.write((char *)&(x[0]), sizeof (x[0]));
@@ -25,9 +24,17 @@ bool MeshIO::save(LosTopos::SurfTrack & st, const std::string & filename, bool b
             os.write((char *)&(x[2]), sizeof (x[2]));
         }
         
-        n = st.m_mesh.nt();
-        os.write((char *)&n, sizeof (size_t));
-        for (size_t i = 0; i < n; i++)
+        const size_t nt = st.m_mesh.nt();
+        size_t num_non_deleted_tris = 0;
+        for (size_t i = 0; i < nt; i++)
+        {
+            const LosTopos::Vec3st &t = st.m_mesh.get_triangle(i);
+            if (t[0] == t[1])
+                continue;
+            ++num_non_deleted_tris;
+        }
+        os.write((char *)&num_non_deleted_tris, sizeof (size_t));
+        for (size_t i = 0; i < nt; i++)
         {
             LosTopos::Vec3st t = st.m_mesh.get_triangle(i);
             if (t[0] == t[1])

--- a/Apps/MultiTrackerSim/Sim.cpp
+++ b/Apps/MultiTrackerSim/Sim.cpp
@@ -223,6 +223,8 @@ bool Sim::init(const std::string & option_file, const std::string & output_direc
     // BB wall constraint: update the infinite masses
     updateBBWallConstraints();
 
+    // mesh improvement
+    m_st->improve_mesh();
     
     // prepare to start the simulation
     m_time = 0;

--- a/Apps/MultiTrackerSim/Sim.cpp
+++ b/Apps/MultiTrackerSim/Sim.cpp
@@ -664,12 +664,12 @@ LosTopos::Vec3c Sim::generate_collapsed_solid_label(LosTopos::SurfTrack & st, si
     std::cout << "Label0 " << (int)label0[0] << (int)label0[1] << (int)label0[2] << std::endl;
     std::cout << "Constraint0 " << constraint0 << std::endl;
     std::cout << "Constraint1 " << constraint1 << std::endl;*/
-    assert(((constraint0 & (1 << 0)) || (constraint0 & (1 << 3))) == (bool)label0[0]);  //x0's physical status of being on the left or right wall should match label0's (i.e. mass's solid indicator)
-    assert(((constraint0 & (1 << 1)) || (constraint0 & (1 << 4))) == (bool)label0[1]);
-    assert(((constraint0 & (1 << 2)) || (constraint0 & (1 << 5))) == (bool)label0[2]);
-    assert(((constraint1 & (1 << 0)) || (constraint1 & (1 << 3))) == (bool)label1[0]);
-    assert(((constraint1 & (1 << 1)) || (constraint1 & (1 << 4))) == (bool)label1[1]);
-    assert(((constraint1 & (1 << 2)) || (constraint1 & (1 << 5))) == (bool)label1[2]);
+    assert(!(bool)label0[0] || ((constraint0 & (1 << 0)) || (constraint0 & (1 << 3))));  //x0's physical status of being on the left or right wall should match label0's (i.e. mass's solid indicator)
+    assert(!(bool)label0[1] || ((constraint0 & (1 << 1)) || (constraint0 & (1 << 4))));
+    assert(!(bool)label0[2] || ((constraint0 & (1 << 2)) || (constraint0 & (1 << 5))));
+    assert(!(bool)label1[0] || ((constraint1 & (1 << 0)) || (constraint1 & (1 << 3))));
+    assert(!(bool)label1[1] || ((constraint1 & (1 << 1)) || (constraint1 & (1 << 4))));
+    assert(!(bool)label1[2] || ((constraint1 & (1 << 2)) || (constraint1 & (1 << 5))));
     
     LosTopos::Vec3c result;  // if either endpoint is constrained, the collapsed point shold be constrained. more specifically it should be on all the walls any of the two endpoints is on (implemented in generate_collapsed_position())
     int result_constraint = (constraint0 | constraint1);
@@ -688,12 +688,12 @@ LosTopos::Vec3c Sim::generate_split_solid_label(LosTopos::SurfTrack & st, size_t
     int constraint0 = onBBWall(Vec3d(x0[0], x0[1], x0[2]));
     int constraint1 = onBBWall(Vec3d(x1[0], x1[1], x1[2]));
     
-    assert(((constraint0 & (1 << 0)) || (constraint0 & (1 << 3))) == (bool)label0[0]);
-    assert(((constraint0 & (1 << 1)) || (constraint0 & (1 << 4))) == (bool)label0[1]);
-    assert(((constraint0 & (1 << 2)) || (constraint0 & (1 << 5))) == (bool)label0[2]);
-    assert(((constraint1 & (1 << 0)) || (constraint1 & (1 << 3))) == (bool)label1[0]);
-    assert(((constraint1 & (1 << 1)) || (constraint1 & (1 << 4))) == (bool)label1[1]);
-    assert(((constraint1 & (1 << 2)) || (constraint1 & (1 << 5))) == (bool)label1[2]);
+    assert(!(bool)label0[0] || ((constraint0 & (1 << 0)) || (constraint0 & (1 << 3))));
+    assert(!(bool)label0[1] || ((constraint0 & (1 << 1)) || (constraint0 & (1 << 4))));
+    assert(!(bool)label0[2] || ((constraint0 & (1 << 2)) || (constraint0 & (1 << 5))));
+    assert(!(bool)label1[0] || ((constraint1 & (1 << 0)) || (constraint1 & (1 << 3))));
+    assert(!(bool)label1[1] || ((constraint1 & (1 << 1)) || (constraint1 & (1 << 4))));
+    assert(!(bool)label1[2] || ((constraint1 & (1 << 2)) || (constraint1 & (1 << 5))));
   
     LosTopos::Vec3c result;  // the splitting midpoint has a positive constraint label only if the two endpoints are on a same wall (sharing a bit in their constraint bitfield representation)
     int result_constraint = (constraint0 & constraint1);

--- a/Apps/MultiTrackerSim/drivers/MCFDriver.cpp
+++ b/Apps/MultiTrackerSim/drivers/MCFDriver.cpp
@@ -16,6 +16,9 @@ bool MCFDriver::step(SurfTrack * st, double dt, bool bbwall)
     // adaptive time stepping
     double dt_left = dt;
     double dt_largest_possible = 0;
+
+    // set newpositions to position
+    st->set_all_newpositions(st->get_positions());
     
     int substep_count = 0;
     while (dt_left > 0 && substep_count < 100)
@@ -26,22 +29,40 @@ bool MCFDriver::step(SurfTrack * st, double dt, bool bbwall)
         dt_largest_possible = determineMaxDt(st, v);
         std::cout << "dt_left = " << dt_left << " max dt = " << dt_largest_possible << std::endl;
         if (dt_largest_possible >= dt_left)
-            dt_largest_possible = dt_left;
+        {
+            dt_largest_possible = dt_left; // clamp dt_largest_possible
+
+            // Setting dt_left to 0 manually as otherwise floating point precision
+            // problems from doing dt_left -= dt_largest_possible can cause
+            // dt_left to be a very small number near zero leading to some issues.
+            dt_left = 0;
+        } else
+        {
+            dt_left -= dt_largest_possible;
+        }
 
         for (size_t i = 0; i < st->m_mesh.nv(); i++)
         {
-           if (st->m_mesh.vertex_is_deleted(i)) {
-              st->set_newposition(i, st->get_position(i));
-              continue;
-           }
-            Vec3d m = st->m_masses[i];
-            Vec3d newpos = st->get_position(i) + Vec3d(v[i][0] / m[0], v[i][1] / m[1], v[i][2] / m[2]) * dt_largest_possible;
+            if (st->m_mesh.vertex_is_deleted(i))
+                continue;
+
+            Vec3d newpos = st->get_newposition(i);
+
+            Vec3d m(1, 1, 1);
+            if (bbwall)
+            {
+                const int onwall = onBBWall(newpos);
+                m[0] = ((onwall & (1 << 0)) || (onwall & (1 << 3)) ? std::numeric_limits<double>::infinity() : 1);
+                m[1] = ((onwall & (1 << 1)) || (onwall & (1 << 4)) ? std::numeric_limits<double>::infinity() : 1);
+                m[2] = ((onwall & (1 << 2)) || (onwall & (1 << 5)) ? std::numeric_limits<double>::infinity() : 1);
+            }
+
+            newpos += Vec3d(v[i][0] / m[0], v[i][1] / m[1], v[i][2] / m[2]) * dt_largest_possible;
             assert(newpos == newpos);
             if (bbwall) newpos = Vec3d(std::min(1.0, std::max(0.0, newpos[0])), std::min(1.0, std::max(0.0, newpos[1])), std::min(1.0, std::max(0.0, newpos[2])));
             st->set_newposition(i, newpos);
         }
         
-        dt_left -= dt_largest_possible;
         substep_count++;
     }
     
@@ -56,59 +77,89 @@ bool MCFDriver::step(SurfTrack * st, double dt, bool bbwall)
     }
 }
 
-double MCFDriver::determineMaxDt(SurfTrack * st, std::vector<Vec3d> & v)
+double MCFDriver::determineMaxDt(const SurfTrack * st, const std::vector<Vec3d> & v)
 {
     double global_max_dt = 1.0;
     for (size_t i = 0; i < st->m_mesh.ne(); i++)
     {
        if (st->m_mesh.edge_is_deleted(i))
           continue;
-        size_t v0 = st->m_mesh.m_edges[i][0];
-        size_t v1 = st->m_mesh.m_edges[i][1];
-        Vec3d edge = st->get_position(v1) - st->get_position(v0);
-        Vec3d rv = v[v1] - v[v0];
-        double approaching_velocity = -dot(rv, edge) / dot(edge, edge);
-        
-        double max_dt = 0;
-        if (approaching_velocity <= 0)
-            max_dt = std::numeric_limits<double>::infinity();
-        else
-            max_dt = 1 / approaching_velocity * 0.8;    // allow the edge to be shrunk by 80% in one time step at most
-        
-        if (max_dt < global_max_dt)
-            global_max_dt = max_dt;
+        const size_t v0 = st->m_mesh.m_edges[i][0];
+        const size_t v1 = st->m_mesh.m_edges[i][1];
+        const Vec3d edge = st->get_newposition(v1) - st->get_newposition(v0);
+        const Vec3d rv = v[v1] - v[v0];
+
+        const double alpha = 0.2; // allow the edge to be shrunk by at most 80% in one time substep
+        const double a = dot(rv, rv);
+        if (a < 1e-6) continue; // both endpoints have same velocity vectors
+        const double b = 2 * dot(rv, edge);
+        const double c = (1 - alpha*alpha) * dot(edge, edge);
+        const double discriminant = b*b - 4*a*c;
+
+        // If discriminant < 0 (no solutions) or discriminant = 0 (one solution),
+        // then there is no constraint on t. Else if discriminant > 0 (two solutions),
+        // and the smaller solution is nonnegative, then that solution is an
+        // upper bound on t. Note that in this case both solutions are nonnegative
+        // or nonpositive.
+        double max_dt = std::numeric_limits<double>::infinity();
+        if (discriminant > 1e-6)
+        {
+            const double smaller_root = (-b - std::sqrt(discriminant)) / (2*a);
+            max_dt = smaller_root < 0 ? std::numeric_limits<double>::infinity() : smaller_root;
+        }
+
+        global_max_dt = std::min(global_max_dt, max_dt);
     }
     
     return global_max_dt;
 }
 
-void MCFDriver::evaluateV(LosTopos::SurfTrack * st, std::vector<LosTopos::Vec3d> & v)
+void MCFDriver::evaluateV(const LosTopos::SurfTrack * st, std::vector<LosTopos::Vec3d> & v)
 {
     const double COEF = 1;
     
     v.resize(st->m_mesh.nv(), Vec3d(0, 0, 0));
+    std::fill(v.begin(), v.end(), Vec3d(0, 0, 0));
+
     for (size_t i = 0; i < st->m_mesh.nt(); i++)
     {
        if (st->m_mesh.triangle_is_deleted(i))
           continue;
 
-        Vec3d p0 = st->get_position(st->m_mesh.m_tris[i][0]);
-        Vec3d p1 = st->get_position(st->m_mesh.m_tris[i][1]);
-        Vec3d p2 = st->get_position(st->m_mesh.m_tris[i][2]);
+        const Vec3d p0 = st->get_newposition(st->m_mesh.m_tris[i][0]);
+        const Vec3d p1 = st->get_newposition(st->m_mesh.m_tris[i][1]);
+        const Vec3d p2 = st->get_newposition(st->m_mesh.m_tris[i][2]);
         
-        Vec3d v01 = p1 - p0;
-        Vec3d v20 = p0 - p2;
+        const Vec3d v01 = p1 - p0;
+        const Vec3d v20 = p0 - p2;
         
-        Vec3d A = cross(v01, -v20);
-        double Anorm = mag(A);
-        Vec3d mul = A / Anorm;
+        const Vec3d A = cross(v01, -v20);
+        const double Anorm = mag(A);
+        const Vec3d mul = A / Anorm;
+        if ((Anorm == 0) || (mul != mul)) // cross product may sometimes be 0 due to degenerate triangles
+            continue;
         
-        Vec3d p2part = COEF * cross(v01, mul);
-        Vec3d p1part = COEF * cross(mul, -v20);
-        Vec3d p0part = -(p1part + p2part);
+        const Vec3d p2part = COEF * cross(v01, mul);
+        const Vec3d p1part = COEF * cross(mul, -v20);
+        const Vec3d p0part = -(p1part + p2part);
 
         v[st->m_mesh.m_tris[i][0]] += p0part;
         v[st->m_mesh.m_tris[i][1]] += p1part;
         v[st->m_mesh.m_tris[i][2]] += p2part;
     }
+}
+
+int MCFDriver::onBBWall(const Vec3d & pos)
+{
+    static const double WALL_THRESHOLD = 1e-6;
+    
+    int walls = 0;
+    if (pos[0] < 0 + WALL_THRESHOLD) walls |= (1 << 0);
+    if (pos[1] < 0 + WALL_THRESHOLD) walls |= (1 << 1);
+    if (pos[2] < 0 + WALL_THRESHOLD) walls |= (1 << 2);
+    if (pos[0] > 1 - WALL_THRESHOLD) walls |= (1 << 3);
+    if (pos[1] > 1 - WALL_THRESHOLD) walls |= (1 << 4);
+    if (pos[2] > 1 - WALL_THRESHOLD) walls |= (1 << 5);
+    
+    return walls;
 }

--- a/Apps/MultiTrackerSim/drivers/MCFDriver.h
+++ b/Apps/MultiTrackerSim/drivers/MCFDriver.h
@@ -15,9 +15,12 @@ class MCFDriver
 public:
     static bool step(LosTopos::SurfTrack * st, double dt, bool bbwall = false);
     
-    static double determineMaxDt(LosTopos::SurfTrack * st, std::vector<LosTopos::Vec3d> & v);
+private:
+    static double determineMaxDt(const LosTopos::SurfTrack * st, const std::vector<LosTopos::Vec3d> & v);
     
-    static void evaluateV(LosTopos::SurfTrack * st, std::vector<LosTopos::Vec3d> & v);
+    static void evaluateV(const LosTopos::SurfTrack * st, std::vector<LosTopos::Vec3d> & v);
+
+    static int onBBWall(const LosTopos::Vec3d& pos);
     
 };
 

--- a/Apps/MultiTrackerViewer/MeshIO.cpp
+++ b/Apps/MultiTrackerViewer/MeshIO.cpp
@@ -13,11 +13,10 @@ bool MeshIO::save(LosTopos::SurfTrack & st, const std::string & filename, bool b
     if (binary)
     {
         std::ofstream os(filename.c_str(), std::ios::binary);
-        size_t n;
         
-        n = st.m_mesh.nv();
-        os.write((char *)&n, sizeof (size_t));
-        for (size_t i = 0; i < n; i++)
+        const size_t nv = st.m_mesh.nv();
+        os.write((char *)&nv, sizeof (size_t));
+        for (size_t i = 0; i < nv; i++)
         {
             LosTopos::Vec3d x = st.get_position(i);
             os.write((char *)&(x[0]), sizeof (x[0]));
@@ -25,9 +24,17 @@ bool MeshIO::save(LosTopos::SurfTrack & st, const std::string & filename, bool b
             os.write((char *)&(x[2]), sizeof (x[2]));
         }
         
-        n = st.m_mesh.nt();
-        os.write((char *)&n, sizeof (size_t));
-        for (size_t i = 0; i < n; i++)
+        const size_t nt = st.m_mesh.nt();
+        size_t num_non_deleted_tris = 0;
+        for (size_t i = 0; i < nt; i++)
+        {
+            const LosTopos::Vec3st &t = st.m_mesh.get_triangle(i);
+            if (t[0] == t[1])
+                continue;
+            ++num_non_deleted_tris;
+        }
+        os.write((char *)&num_non_deleted_tris, sizeof (size_t));
+        for (size_t i = 0; i < nt; i++)
         {
             LosTopos::Vec3st t = st.m_mesh.get_triangle(i);
             if (t[0] == t[1])

--- a/LosTopos/LosTopos3D/meshsnapper.cpp
+++ b/LosTopos/LosTopos3D/meshsnapper.cpp
@@ -301,7 +301,7 @@ bool MeshSnapper::snap_vertex_pair( size_t vertex_to_keep, size_t vertex_to_dele
         if (m0[i] == std::numeric_limits<double>::infinity() && m1[i] == std::numeric_limits<double>::infinity())
         {
             // both vertices are constrained in this direction: this requires the two cooresponding coordindates are equal
-            assert(m_surf.get_position(vertex_to_delete)[i] == m_surf.get_position(vertex_to_keep)[i]);
+            assert(std::abs(m_surf.get_position(vertex_to_delete)[i] - m_surf.get_position(vertex_to_keep)[i]) < 1e-6);
             vertex_new_position[i] = m_surf.get_position(vertex_to_delete)[i];
         } else if (m0[i] == std::numeric_limits<double>::infinity())
         {

--- a/LosTopos/LosTopos3D/surftrack.cpp
+++ b/LosTopos/LosTopos3D/surftrack.cpp
@@ -409,7 +409,7 @@ void SurfTrack::defrag_mesh( )
     int vert_delete_count = 0;
     for (size_t i = 0; i < get_num_vertices(); ++i)
     {
-       if (m_mesh.triangle_is_deleted(i))
+       if (m_mesh.vertex_is_deleted(i))
        {
           vert_delete_count++;
        }

--- a/LosTopos/common/util.h
+++ b/LosTopos/common/util.h
@@ -204,9 +204,9 @@ inline T ramp(T r)
 inline int lround(double x)
 {
     if(x>0)
-        return (x-floor(x)<0.5) ? (int)floor(x) : (int)ceil(x);
+        return (x-std::floor(x)<0.5) ? (int)std::floor(x) : (int)std::ceil(x);
     else
-        return (x-floor(x)<=0.5) ? (int)floor(x) : (int)ceil(x);
+        return (x-std::floor(x)<=0.5) ? (int)std::floor(x) : (int)std::ceil(x);
 }
 
 inline double remainder(double x, double y)


### PR DESCRIPTION
The following bugs have been fixed:

- Assertions with floating point numbers:
  - Some assertions were doing floating point comparison with exact equality, which is not reliable due to floating point precision. These have been replaced with a threshold for comparison.

- Assertions with bounding box walls and solid vertices:
  - Fixed assertions that check that vertices with solid vertex labels set to true are on the appropriate bounding box wall. Previously these assertions were checking that any vertex on a bounding box wall had to have a corresponding solid vertex label set to true.

- MeshIO reading past end of file:
  - Fixed how `MeshIO::save()` encodes data so that `MeshIO::load()` does not read past the end of the file.

- Fixed incorrect counting of deleted vertices in `defrag_mesh()`.

- MCF driver files have been fixed so that the MCF test case now runs correctly:
  - Fixed substepping so that vertex positions would accumulate rather than be reset each substep.
  - Removed unintentional accumulation of vertex velocities across substeps.
  - Fixed various parts of the driver to use the updated position at each substep.
  - Handled floating point precision issues and divide by zero cases.
  - Fixed computation of determining maximum time step allowed to shrink edge by at most 80%.

- Remeshing is now done as soon as the initial mesh is loaded in. This was necessary to fix the MCF case and should be ideal for other cases as well.