### PR TITLE
Fix minor bugs in edge collapse

### DIFF
--- a/LosTopos/LosTopos3D/edgecollapser.cpp
+++ b/LosTopos/LosTopos3D/edgecollapser.cpp
@@ -845,19 +845,10 @@ bool EdgeCollapser::collapse_edge( size_t edge )
     if ( m_surf.get_position(m_surf.m_mesh.m_edges[edge][1]) != m_surf.get_position(m_surf.m_mesh.m_edges[edge][0]) )
         //if ( mag ( m_surf.get_position(m_surf.m_mesh.m_edges[edge][1]) - m_surf.get_position(m_surf.m_mesh.m_edges[edge][0]) ) > 0 )
     {
-        
-        // Change source vertex predicted position to superimpose onto destination vertex
-        m_surf.set_newposition( vertex_to_keep, vertex_new_position );
-        m_surf.set_newposition( vertex_to_delete, vertex_new_position );
-        
         bool volume_change = collapse_edge_introduces_volume_change( vertex_to_delete, vertex_to_keep, edge, vertex_new_position );
         
         if ( volume_change && !m_surf.m_aggressive_mode)
         {
-            // Restore saved positions which were changed by the function we just called.
-            m_surf.set_newposition( vertex_to_keep, m_surf.get_position(vertex_to_keep) );
-            m_surf.set_newposition( vertex_to_delete, m_surf.get_position(vertex_to_delete) );
-            
             g_stats.add_to_int( "EdgeCollapser:collapse_volume_change", 1 );
             
             if ( m_surf.m_verbose ) { std::cout << "collapse_volume_change" << std::endl; }
@@ -868,10 +859,6 @@ bool EdgeCollapser::collapse_edge( size_t edge )
         
         if ( normal_inversion && !m_surf.m_aggressive_mode)//&& (edge_len >= m_t1_pull_apart_distance) )
         {
-            // Restore saved positions which were changed by the function we just called.
-            m_surf.set_newposition( vertex_to_keep, m_surf.get_position(vertex_to_keep) );
-            m_surf.set_newposition( vertex_to_delete, m_surf.get_position(vertex_to_delete) );
-            
             if ( m_surf.m_verbose ) { std::cout << "normal_inversion" << std::endl; }
             return false;
         }
@@ -880,10 +867,6 @@ bool EdgeCollapser::collapse_edge( size_t edge )
         
         if ( bad_angle && !m_surf.m_aggressive_mode )//&& edge_len >= m_t1_pull_apart_distance )
         {
-            // Restore saved positions which were changed by the function we just called.
-            m_surf.set_newposition( vertex_to_keep, m_surf.get_position(vertex_to_keep) );
-            m_surf.set_newposition( vertex_to_delete, m_surf.get_position(vertex_to_delete) );
-            
             if ( m_surf.m_verbose ) { std::cout << "bad_angle" << std::endl; }
             
             g_stats.add_to_int( "EdgeCollapser:collapse_bad_angle", 1 );
@@ -891,6 +874,10 @@ bool EdgeCollapser::collapse_edge( size_t edge )
             
         }
         
+        // Change source vertex predicted position to superimpose onto destination vertex
+        m_surf.set_newposition( vertex_to_keep, vertex_new_position );
+        m_surf.set_newposition( vertex_to_delete, vertex_new_position );
+
         bool collision = false;
         
         if ( m_surf.m_collision_safety )

--- a/LosTopos/LosTopos3D/edgecollapser.cpp
+++ b/LosTopos/LosTopos3D/edgecollapser.cpp
@@ -1027,6 +1027,8 @@ bool EdgeCollapser::edge_is_collapsible( size_t edge_index, double& current_leng
     
     //skip boundary edges if we're not remeshing those
     if(!m_remesh_boundaries && m_surf.m_mesh.m_is_boundary_edge[edge_index]) { return false; }
+
+    current_length = m_surf.get_edge_length(edge_index);
     
     //try to collapse based on small angles
     size_t vertex_a = m_surf.m_mesh.m_edges[edge_index][0];
@@ -1054,7 +1056,6 @@ bool EdgeCollapser::edge_is_collapsible( size_t edge_index, double& current_leng
         //    return true;
     }
     
-    current_length = m_surf.get_edge_length(edge_index);
     if ( m_use_curvature )
     {
         

--- a/LosTopos/LosTopos3D/edgecollapser.h
+++ b/LosTopos/LosTopos3D/edgecollapser.h
@@ -120,6 +120,7 @@ private:
     /// Determine whether collapsing an edge will introduce an unacceptable change in volume.
     ///
     bool collapse_edge_introduces_volume_change( size_t source_vertex, 
+                                                size_t destination_vertex, 
                                                 size_t edge_index, 
                                                 const Vec3d& vertex_new_position );   
     

--- a/LosTopos/LosTopos3D/edgeflipper.cpp
+++ b/LosTopos/LosTopos3D/edgeflipper.cpp
@@ -355,14 +355,14 @@ bool EdgeFlipper::flip_edge( size_t edge,
     normalize(new_normal0);
     normalize(new_normal1);
     
-    if ( new_area0 < std::min(m_surf.m_min_triangle_area, std::min(old_area0, old_area0) * 0.5) )
+    if ( new_area0 < std::min(m_surf.m_min_triangle_area, std::min(old_area0, old_area1) * 0.5) )
     {
         if ( m_surf.m_verbose ) { std::cout << "edge flip rejected: area0 too small" << std::endl;    }
         g_stats.add_to_int( "EdgeFlipper:edge_flip_new_area_too_small", 1 );
         return false;
     }
     
-    if ( new_area1 < std::min(m_surf.m_min_triangle_area, std::min(old_area0, old_area0) * 0.5) )
+    if ( new_area1 < std::min(m_surf.m_min_triangle_area, std::min(old_area0, old_area1) * 0.5) )
     {
         if ( m_surf.m_verbose ) { std::cout << "edge flip rejected: area1 too small" << std::endl; }
         g_stats.add_to_int( "EdgeFlipper:edge_flip_new_area_too_small", 1 );


### PR DESCRIPTION
- Fix edge collapse volume change check to account for movement of both vertices on edge.
- Compute edge lengths for all collapsible edges.
- Clean up unnecessary vertex position changes during edge collapse.