### PR TITLE
Fix bugs in EdgeSplitter, FaceSplitter, T1Transition, and more

### DIFF
--- a/LosTopos/LosTopos3D/edgecollapser.cpp
+++ b/LosTopos/LosTopos3D/edgecollapser.cpp
@@ -208,7 +208,7 @@ bool EdgeCollapser::collapse_edge_pseudo_motion_introduces_collision( size_t sou
                 double distance, s0, s2;
                 Vec3d normal;
                 check_edge_edge_proximity(m_surf.get_newposition(e0[0]), m_surf.get_newposition(e0[1]), m_surf.get_newposition(e1[0]), m_surf.get_newposition(e1[1]), distance, s0, s2, normal);
-                if (distance == 0)
+                if (distance < m_surf.m_improve_collision_epsilon)
                     return true;
             }
             
@@ -226,7 +226,7 @@ bool EdgeCollapser::collapse_edge_pseudo_motion_introduces_collision( size_t sou
                 double distance, s1, s2, s3;
                 Vec3d normal;
                 check_point_triangle_proximity(m_surf.get_newposition(v), m_surf.get_newposition(tri[0]), m_surf.get_newposition(tri[1]), m_surf.get_newposition(tri[2]), distance, s1, s2, s3, normal);
-                if (distance == 0)
+                if (distance < m_surf.m_improve_collision_epsilon)
                     return true;
             }
         }

--- a/LosTopos/LosTopos3D/facesplitter.cpp
+++ b/LosTopos/LosTopos3D/facesplitter.cpp
@@ -401,9 +401,9 @@ bool FaceSplitter::split_face( size_t face, size_t& result_vertex, bool specify_
     double max_current_angle = max_triangle_angle(va, vb, vc);
     
     double max_new_angle = 0;
-    max_new_angle = min( max_new_angle, max_triangle_angle( va, vb, new_vertex_position ) );
-    max_new_angle = min( max_new_angle, max_triangle_angle( vb, vc, new_vertex_position ) );
-    max_new_angle = min( max_new_angle, max_triangle_angle( vc, va, new_vertex_position ) );
+    max_new_angle = max( max_new_angle, max_triangle_angle( va, vb, new_vertex_position ) );
+    max_new_angle = max( max_new_angle, max_triangle_angle( vb, vc, new_vertex_position ) );
+    max_new_angle = max( max_new_angle, max_triangle_angle( vc, va, new_vertex_position ) );
     
     // if new angle is greater than the allowed angle, and doesn't
     // improve the current max angle, prevent the split

--- a/LosTopos/LosTopos3D/facesplitter.cpp
+++ b/LosTopos/LosTopos3D/facesplitter.cpp
@@ -443,7 +443,7 @@ bool FaceSplitter::split_face( size_t face, size_t& result_vertex, bool specify_
     }
     
     if(!point_okay) { //try the default barycenter point instead.
-        if ( !split_face_pseudo_motion_introduces_intersection( new_vertex_position, new_vertex_smooth_position, face) )
+        if ( split_face_pseudo_motion_introduces_intersection( new_vertex_position, new_vertex_smooth_position, face) )
         {
             g_stats.add_to_int( "FaceSplitter:split_midpoint_collisions", 1 );
             

--- a/LosTopos/LosTopos3D/facesplitter.cpp
+++ b/LosTopos/LosTopos3D/facesplitter.cpp
@@ -411,8 +411,8 @@ bool FaceSplitter::split_face( size_t face, size_t& result_vertex, bool specify_
     if ( rad2deg(max_new_angle) > m_surf.m_max_triangle_angle )
     {
         
-        // if new triangle improves a large angle, allow it
-        if ( rad2deg(max_new_angle) < rad2deg(max_current_angle) )
+        // if new triangle improves a large angle, allow it, else prevent the split
+        if ( rad2deg(max_new_angle) > rad2deg(max_current_angle) )
         {
             g_stats.add_to_int( "EdgeSplitter:edge_split_large_angle", 1 );
             return false;

--- a/LosTopos/LosTopos3D/meshsnapper.cpp
+++ b/LosTopos/LosTopos3D/meshsnapper.cpp
@@ -263,6 +263,52 @@ bool MeshSnapper::snap_pseudo_motion_introduces_collision( size_t source_vertex,
     {
         return true;
     }
+
+    // Also check proximity: if any proximity check returns zero distance, this collapse cannot be allowed either.
+    // Because the CCD above is geometrically exact, it sometimes returns different result than the proximity check below (proximity
+    //  distance = 0, but CCD says no collision). If distance is 0, the subsequent proximity handling will produce NaNs, so it is
+    //  problematic too.
+    
+    for (size_t i = 0; i < collision_candidates.size(); i++)
+    {
+        const Vec3st & candidate = collision_candidates[i];
+        if (candidate[2] == 1)
+        {
+            // edge-edge
+            Vec2st e0 = m_surf.m_mesh.m_edges[candidate[0]];
+            Vec2st e1 = m_surf.m_mesh.m_edges[candidate[1]];
+            
+            if (e0[0] == e0[1]) continue;
+            if (e1[0] == e1[1]) continue;
+            
+            if (e0[0] != e1[0] && e0[0] != e1[1] && e0[1] != e1[0] && e0[1] != e1[1])
+            {
+                double distance, s0, s2;
+                Vec3d normal;
+                check_edge_edge_proximity(m_surf.get_newposition(e0[0]), m_surf.get_newposition(e0[1]), m_surf.get_newposition(e1[0]), m_surf.get_newposition(e1[1]), distance, s0, s2, normal);
+                if (distance < m_surf.m_improve_collision_epsilon)
+                    return true;
+            }
+            
+        } else
+        {
+            // point-triangle
+            size_t t = candidate[0];
+            const Vec3st & tri = m_surf.m_mesh.get_triangle(t);
+            size_t v = candidate[1];
+            
+            if (tri[0] == tri[1]) continue;
+            
+            if (tri[0] != v && tri[1] != v && tri[2] != v)
+            {
+                double distance, s1, s2, s3;
+                Vec3d normal;
+                check_point_triangle_proximity(m_surf.get_newposition(v), m_surf.get_newposition(tri[0]), m_surf.get_newposition(tri[1]), m_surf.get_newposition(tri[2]), distance, s1, s2, s3, normal);
+                if (distance < m_surf.m_improve_collision_epsilon)
+                    return true;
+            }
+        }
+    }
     
     return false;
     

--- a/LosTopos/LosTopos3D/t1transition.cpp
+++ b/LosTopos/LosTopos3D/t1transition.cpp
@@ -785,15 +785,25 @@ void T1Transition::triangulate_popped_vertex(size_t xj, int A, int B, size_t a, 
     }
     
     std::vector<size_t> A_edges;
-    for (size_t j = 0; j < mesh.m_vertex_to_edge_map[xj].size(); j++)
+    for (const auto& edge_idx : mesh.m_vertex_to_edge_map[xj])
     {
-        size_t edge = mesh.m_vertex_to_edge_map[xj][j];
-        for (size_t k = 0; k < mesh.m_edge_to_triangle_map[edge].size(); k++)
+        bool exists_A_tri = false;
+        bool exists_B_tri = false;
+
+        for (const auto& tri_idx : mesh.m_edge_to_triangle_map[edge_idx])
         {
-            Vec2i label = mesh.get_triangle_label(mesh.m_edge_to_triangle_map[edge][k]);
-            if (label[0] == A || label[1] == A)
+            const Vec2i& label = mesh.get_triangle_label(tri_idx);
+            const bool has_A_label = (label[0] == A || label[1] == A);
+
+            if (has_A_label)
+                exists_A_tri = true;
+
+            if (!has_A_label)
+                exists_B_tri = true;
+
+            if (exists_A_tri && exists_B_tri)
             {
-                A_edges.push_back(edge);
+                A_edges.push_back(edge_idx);
                 break;
             }
         }

--- a/VS_build/LosTopos/LosTopos.vcxproj
+++ b/VS_build/LosTopos/LosTopos.vcxproj
@@ -28,26 +28,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/VS_build/MultiTracker/MultiTracker.vcxproj
+++ b/VS_build/MultiTracker/MultiTracker.vcxproj
@@ -28,26 +28,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <UseIntelMKL>No</UseIntelMKL>
@@ -98,6 +98,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>C:\Users\comin\Documents\MultiTrackerFolders\MultiTrackerSerial\LosTopos\common\tunicate;C:\Users\comin\Documents\MultiTrackerFolders\MultiTrackerSerial\LosTopos\common;C:\Users\comin\Documents\MultiTrackerFolders\MultiTrackerSerial\LosTopos\LosTopos3D;C:\Users\comin\Documents\MultiTrackerFolders\freeglut-3.2.2\include;C:\Users\comin\Documents\MultiTrackerFolders\eigen-3.4.0</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -112,7 +113,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>C:\Users\Christopher Batty\Documents\Libraries\freeglut_3.0\include;..\..\LosTopos\common;..\..\LosTopos\common\tunicate;..\..\LosTopos\LosTopos3D;C:\Users\Christopher Batty\Documents\Libraries\eigen_3.3.4;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Users\comin\Documents\MultiTrackerFolders\MultiTrackerSerial\LosTopos\common\tunicate;C:\Users\comin\Documents\MultiTrackerFolders\MultiTrackerSerial\LosTopos\common;C:\Users\comin\Documents\MultiTrackerFolders\MultiTrackerSerial\LosTopos\LosTopos3D;C:\Users\comin\Documents\MultiTrackerFolders\freeglut-3.2.2\include;C:\Users\comin\Documents\MultiTrackerFolders\eigen-3.4.0</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>

--- a/VS_build/MultiTrackerView/MultiTrackerView.vcxproj
+++ b/VS_build/MultiTrackerView/MultiTrackerView.vcxproj
@@ -28,26 +28,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -116,13 +116,14 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>C:\Users\batty\Documents\Research\Projects\MultiTracker\GitHub\MultiTracker\LosTopos\LosTopos3D;C:\Users\batty\Documents\Libraries\freeglut-2.8.1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Users\comin\Documents\MultiTrackerFolders\freeglut-3.2.2\include;C:\Users\comin\Documents\MultiTrackerFolders\MultiTrackerSerial\LosTopos\common;C:\Users\comin\Documents\MultiTrackerFolders\MultiTrackerSerial\LosTopos\LosTopos3D;C:\Users\comin\Documents\MultiTrackerFolders\eigen-3.4.0</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>C:\Users\comin\Documents\MultiTrackerFolders\freeglut\lib\Release</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -134,7 +135,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\LosTopos\LosTopos3D;C:\Users\Christopher Batty\Documents\Libraries\freeglut_3.0\include;..\..\LosTopos\common;..\..\common\tunicate;C:\Users\Christopher Batty\Documents\Libraries\eigen_3.3.4;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Users\comin\Documents\MultiTrackerFolders\freeglut-3.2.2\include;C:\Users\comin\Documents\MultiTrackerFolders\MultiTrackerSerial\LosTopos\common;C:\Users\comin\Documents\MultiTrackerFolders\MultiTrackerSerial\LosTopos\LosTopos3D;C:\Users\comin\Documents\MultiTrackerFolders\eigen-3.4.0</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
@@ -142,7 +143,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Users\Christopher Batty\Documents\Libraries\freeglut_3.0\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Users\comin\Documents\MultiTrackerFolders\freeglut\lib\Release</AdditionalLibraryDirectories>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
The following bugs were fixed:
- Added missing proximity checks in some remeshing operations.
- Extended checks for minimum edge lengths in EdgeSplitter to newly created edges as well.
- Fixed various small mistakes in FaceSplitter.
- Fixed conditions for gathering "A edges" in T1 transitions.